### PR TITLE
Excluded directories need to have * to be excluded

### DIFF
--- a/s3_excludes
+++ b/s3_excludes
@@ -1,4 +1,4 @@
 # These files will be excluded when syncing to S3
-u/
-assets/.sync/
-logs/
+u/*
+assets/.sync/*
+logs/*


### PR DESCRIPTION
having simply `u/` in the s3_excludes file does not exclude all the files in it. It needs to be `u/*`. Updated this for all dirs excluded for door43.org

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/door43.org/164)
<!-- Reviewable:end -->
