### PR TITLE
Issue #173: Update to make OBS and Bible commit pages share css and js

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1
+- 2.2.2
 script: ./cibuild.sh
 env:
   global:

--- a/_layouts/bible.html
+++ b/_layouts/bible.html
@@ -4,42 +4,44 @@
 {% include head.html %}
 
 <body itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<link rel="stylesheet" type="text/css" href="{{ '/css/commit-page.css' | prepend: site.baseurl }}">
 <link rel="stylesheet" type="text/css" href="{{ '/css/bible.css' | prepend: site.baseurl }}">
 
 {% include header.html %}
 
-<div class="content-container container">
-  <main class="content" role="main" itemprop="mainContentOfPage">
-    <article itemscope="itemscope" itemtype="http://schema.org/CreativeWork">
-      <header>
-        <div class="bible-header-title">
-          <h1 itemprop="headline">
-            <span class="fa fa-star bible-starred-icon"></span>
-            <span id="bible-h1">Header</span>
-            <span class="fa fa-check-circle-o bible-build-status-icon"></span>
-          </h1>
-        </div>
-        <div class="bible-last-updated">
-          <span id="last-updated">Updated 1 hour ago</span>
-          <span class="fa fa-eye"></span>
-          <span id="bible-num-of-views">2</span>
-        </div>
-      </header>
-      <div class="page-content row">
-        <div class="col-md-3 sidebar" role="complementary">
-          <div id="bible-sidebar">
-            { sidebar }
-          </div>
-        </div>
-        <div class="col-md-9" role="main" id="bible-content">
-          { content }
-        </div>
-      </div>
-    </article>
-  </main>
+<div class="content-container container bible-container">
+    <main class="content" role="main" itemprop="mainContentOfPage">
+        <article itemscope="itemscope" itemtype="http://schema.org/CreativeWork">
+            <header>
+                <div id="header-title">
+                    <h1 itemprop="headline">
+                        <span id="starred-icon"><i class="fa fa-star-o"></i></span>
+                        <span id="h1">Header</span>
+                        <span id="build-status-icon"><i class="fa fa-question-circle"></i></span>
+                    </h1>
+                </div>
+                <div id="sub-header">
+                    <span id="last-updated">Updated ? hours ago</span>
+                    <span id="views"><i class="fa fa-eye"></i></span>
+                    <span id="num-of-views">? views</span>
+                </div>
+            </header>
+            <div class="page-content row">
+                <div id="left-sidebar" class="col-md-3 sidebar" role="complementary">
+                    { sidebar }
+                </div>
+                <div class="col-md-9" role="main" id="content">
+                    { content }
+                </div>
+            </div>
+        </article>
+    </main>
 </div>
 
 {% include footer.html %}
+
+<script type="text/javascript" src="{{ '/js/general-tools.js' | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ '/js/commit-page.js' | prepend: site.baseurl }}"></script>
 
 </body>
 

--- a/_layouts/obs.html
+++ b/_layouts/obs.html
@@ -4,34 +4,33 @@
 {% include head.html %}
 
 <body itemscope="itemscope" itemtype="http://schema.org/WebPage">
+<link rel="stylesheet" type="text/css" href="{{ '/css/commit-page.css' | prepend: site.baseurl }}">
 <link rel="stylesheet" type="text/css" href="{{ '/css/obs.css' | prepend: site.baseurl }}">
 
 {% include header.html %}
 
-<div class="content-container container">
+<div class="content-container container obs-container">
     <main class="content" role="main" itemprop="mainContentOfPage">
         <article itemscope="itemscope" itemtype="http://schema.org/CreativeWork">
             <header>
-                <div class="obs-header-title">
+                <div id="header-title">
                     <h1 itemprop="headline">
-                        <span class="fa fa-star obs-starred-icon"></span>
-                        <span id="obs-h1">Header</span>
-                        <span class="fa fa-check-circle-o obs-build-status-icon"></span>
+                        <span id="starred-icon"><i class="fa fa-star-o"></i></span>
+                        <span id="h1">Header</span>
+                        <span id="build-status-icon"><i class="fa fa-question-circle"></i></span>
                     </h1>
                 </div>
-                <div class="obs-last-updated">
-                    <span id="last-updated">Updated 1 hour ago</span>
-                    <span class="fa fa-eye"></span>
-                    <span id="obs-num-of-views">2</span>
+                <div id="sub-header">
+                    <span id="last-updated">Updated ? hours ago</span>
+                    <span id="views"><i class="fa fa-eye"></i></span>
+                    <span id="num-of-views">? views</span>
                 </div>
             </header>
             <div class="page-content row">
-                <div class="col-md-3 sidebar" role="complementary">
-                    <div id="obs-sidebar">
-                        { sidebar }
-                    </div>
+                <div id="left-sidebar" class="col-md-3 sidebar" role="complementary">
+                    { sidebar }
                 </div>
-                <div class="col-md-9" role="main" id="obs-content">
+                <div class="col-md-9" role="main" id="content">
                     { content }
                 </div>
             </div>
@@ -40,6 +39,9 @@
 </div>
 
 {% include footer.html %}
+
+<script type="text/javascript" src="{{ '/js/general-tools.js' | prepend: site.baseurl }}"></script>
+<script type="text/javascript" src="{{ '/js/commit-page.js' | prepend: site.baseurl }}"></script>
 
 </body>
 

--- a/css/bible.scss
+++ b/css/bible.scss
@@ -5,39 +5,6 @@
 /**
  * Style for Bible pages
  */
-div.bible-header-title {
-  h1 {
-    margin: 0;
 
-    span.bible-starred-icon {
-      font-size: 26px;
-      vertical-align: middle;
-      color: #3ebcfe
-    }
-
-    span.bible-build-status-icon {
-      font-size: 40px;
-      font-weight: 300;
-      vertical-align: middle;
-
-      &:hover {
-        color: #3ebcfe
-      }
-    }
-
-    span#bible-h1 {
-      //something
-    }
-  }
-}
-
-div.bible-last-updated {
-  margin: 0 0 12px 35px;
-  font-size: 16px;
-
-  span#last-updated {
-    font-weight: 400;
-    font-style: italic;
-    margin-right: 30px;
-  }
+.bible-container {
 }

--- a/css/commit-page.scss
+++ b/css/commit-page.scss
@@ -1,0 +1,49 @@
+---
+---
+@charset "utf-8";
+
+/**
+ * Style for project commit pages
+ */
+
+#header-title {
+    h1 {
+        margin: 0;
+
+        #starred-icon {
+            i {
+                font-size: 26px;
+                vertical-align: middle;
+                color: #000000;
+            }
+        }
+
+        #starred-icon.starred {
+            i {
+                color: #3ebcfe;
+            }
+        }
+
+        #build-status-icon {
+            i {
+                font-size: 40px;
+                font-weight: 300;
+                vertical-align: middle;
+            }
+            i:hover {
+                color: #3ebcfe;
+            }
+        }
+    }
+}
+
+#sub-header {
+    margin: 0 0 12px 35px;
+    font-size: 16px;
+
+    #last-updated {
+        font-weight: 400;
+        font-style: italic;
+        margin-right: 30px;
+    }
+}

--- a/css/obs.scss
+++ b/css/obs.scss
@@ -5,39 +5,6 @@
 /**
  * Style for OBS pages
  */
-div.obs-header-title {
-  h1 {
-    margin: 0;
 
-    span.obs-starred-icon {
-      font-size: 26px;
-      vertical-align: middle;
-      color: #3ebcfe
-    }
-
-    span.obs-build-status-icon {
-      font-size: 40px;
-      font-weight: 300;
-      vertical-align: middle;
-
-      &:hover {
-        color: #3ebcfe
-      }
-    }
-
-    span#obs-h1 {
-      //something
-    }
-  }
-}
-
-div.obs-last-updated {
-  margin: 0 0 12px 35px;
-  font-size: 16px;
-
-  span#last-updated {
-    font-weight: 400;
-    font-style: italic;
-    margin-right: 30px;
-  }
+.obs-container {
 }

--- a/js/commit-page.js
+++ b/js/commit-page.js
@@ -40,7 +40,7 @@ $(document).ready(function(){
         statusIcon = getStatusIcon(commit.status)
 
         if(commit.id == myCommitId){
-          $('#last-updated').html(timeSince(date));
+          $('#last-updated').html("Update "+timeSince(date)+" ago");
           $('#build-status-icon i').attr("class", "fa "+statusIcon);
         }
 

--- a/js/commit-page.js
+++ b/js/commit-page.js
@@ -3,29 +3,17 @@
  */
 
 $(document).ready(function(){
-  var url_parts = window.location.href.split('?')[0].split('/');
-  var parent_url = url_parts.slice(0,-2).join('/');
-  var myCommitId = url_parts.slice(-1);
-
-  var request;
-  if(window.XMLHttpRequest)
-    request = new XMLHttpRequest();
-  else
-    request = new ActiveXObject("Microsoft.XMLHTTP");
-
   $.getJSON( "build_log.json", function(myLog) {
+    var myCommitId = myLog.commit_id.substring(0, 10);
+    $('#last-updated').html("Updated "+timeSince(new Date(myLog.created_at))+" ago");
+    $('#build-status-icon i').attr("class", "fa "+getStatusIcon(myLog.status));
+
     console.log("Building sidebar for "+myCommitId);
 
-    $('#left-sidebar').html('<div><h1>Revisions</h1><table width="100%" id="revisions"></table></div>');
+    $('#left-sidebar #revisions').empty()
 
     $.getJSON("../project.json", function (project) {
       $.each(project.commits.reverse(), function (index, commit) {
-        request.open('GET', parent_url+"/"+commit.id+"/01.html", false);
-        request.send();
-        if (request.status === 404) {
-           return true;
-        }
-
         date = new Date(commit.created_at);
         var options = {
           year: "numeric",
@@ -39,11 +27,6 @@ $(document).ready(function(){
 
         statusIcon = getStatusIcon(commit.status)
 
-        if(commit.id == myCommitId){
-          $('#last-updated').html("Updated "+timeSince(date)+" ago");
-          $('#build-status-icon i').attr("class", "fa "+statusIcon);
-        }
-
         var html = '<tr><td>';
         if(commit.id == myCommitId){
           html += '<b>'+dateStr+'</b>';
@@ -51,7 +34,7 @@ $(document).ready(function(){
         else
           html += '<a href="../' + commit.id + '/index.html">' + dateStr + '</a>';
         html += '</td><td><i class="fa '+statusIcon+'"></i></td></tr>';
-        $('#revisions').append(html);
+        $('#left-sidebar #revisions').append(html);
       }); // End each
     })
     .done(function () {

--- a/js/commit-page.js
+++ b/js/commit-page.js
@@ -20,8 +20,8 @@ $(document).ready(function(){
 
     $.getJSON("../project.json", function (project) {
       $.each(project.commits.reverse(), function (index, commit) {
-	    request.open('GET', parent_url+"/"+commit.id+"/01.html", false);
-	    request.send();
+        request.open('GET', parent_url+"/"+commit.id+"/01.html", false);
+        request.send();
         if (request.status === 404) {
            return true;
         }

--- a/js/commit-page.js
+++ b/js/commit-page.js
@@ -40,7 +40,7 @@ $(document).ready(function(){
         statusIcon = getStatusIcon(commit.status)
 
         if(commit.id == myCommitId){
-          $('#last-updated').html("Update "+timeSince(date)+" ago");
+          $('#last-updated').html("Updated "+timeSince(date)+" ago");
           $('#build-status-icon i').attr("class", "fa "+statusIcon);
         }
 

--- a/js/commit-page.js
+++ b/js/commit-page.js
@@ -1,0 +1,71 @@
+/**
+ * Javascript for project commit pages to update the status and build the left sidebar
+ */
+
+$(document).ready(function(){
+  var url_parts = window.location.href.split('?')[0].split('/');
+  var parent_url = url_parts.slice(0,-2).join('/');
+  var myCommitId = url_parts.slice(-1);
+
+  var request;
+  if(window.XMLHttpRequest)
+    request = new XMLHttpRequest();
+  else
+    request = new ActiveXObject("Microsoft.XMLHTTP");
+
+  $.getJSON( "build_log.json", function(myLog) {
+    console.log("Building sidebar for "+myCommitId);
+
+    $('#left-sidebar').html('<div><h1>Revisions</h1><table width="100%" id="revisions"></table></div>');
+
+    $.getJSON("../project.json", function (project) {
+      $.each(project.commits.reverse(), function (index, commit) {
+	    request.open('GET', parent_url+"/"+commit.id+"/01.html", false);
+	    request.send();
+        if (request.status === 404) {
+           return true;
+        }
+
+        date = new Date(commit.created_at);
+        var options = {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+          hour: "numeric",
+          minute: "numeric",
+          timeZone: "UTC"
+        };
+        dateStr = date.toLocaleString("en-US", options);
+
+        statusIcon = getStatusIcon(commit.status)
+
+        if(commit.id == myCommitId){
+          $('#last-updated').html(timeSince(date));
+          $('#build-status-icon i').attr("class", "fa "+statusIcon);
+        }
+
+        var html = '<tr><td>';
+        if(commit.id == myCommitId){
+          html += '<b>'+dateStr+'</b>';
+        }
+        else
+          html += '<a href="../' + commit.id + '/index.html">' + dateStr + '</a>';
+        html += '</td><td><i class="fa '+statusIcon+'"></i></td></tr>';
+        $('#revisions').append(html);
+      }); // End each
+    })
+    .done(function () {
+      console.log("processed project.json");
+    })
+    .fail(function () {
+      console.log("error reading project.json");
+    }); // End getJSON
+  })
+  .done(function () {
+    console.log("processed my own build_log.json");
+  })
+  .fail(function () {
+    console.log("error reading my own build_log.json");
+  }); // End getJSON
+});
+

--- a/js/general-tools.js
+++ b/js/general-tools.js
@@ -1,0 +1,41 @@
+/**
+ * General functions for generating icons, dates, etc.
+ */
+
+function timeSince(date) {
+    var seconds = Math.floor((new Date() - date) / 1000);
+    var interval = Math.floor(seconds / 31536000);
+
+    if (interval > 1) {
+        return interval + " years";
+    }
+    interval = Math.floor(seconds / 2592000);
+    if (interval > 1) {
+        return interval + " months";
+    }
+    interval = Math.floor(seconds / 86400);
+    if (interval > 1) {
+        return interval + " days";
+    }
+    interval = Math.floor(seconds / 3600);
+    if (interval > 1) {
+        return interval + " hours";
+    }
+    interval = Math.floor(seconds / 60);
+    if (interval > 1) {
+        return interval + " minutes";
+    }
+    return Math.floor(seconds) + " seconds";
+}
+
+function getStatusIcon(status) {
+    switch(status){
+        case 'requested': return 'fa-spinner';
+        case 'started': return 'fa-spinner';
+        case 'success': return 'fa-check-circle-o';
+        case 'warnings': return 'fa-exclamation';
+        case 'critical': return 'fa-times-circle-o';
+        case 'failed':
+        default: return 'fa-chain-broken';
+    }
+}


### PR DESCRIPTION
This edits what @phillip-hopper has done to make it so both the obs.html and bible.html templates use the same IDs and classes for their commit page so the javascript (commit-page.js) can be used for both. 

I have added a bible/obs_container class to each and kept their obs.scss and bible.scss css files if and when we do add elements that pertain only to them, such as a selector for OBS stories, Bible books, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/door43.org/182)
<!-- Reviewable:end -->
