### PR TITLE
Added `make assets` target for syncing assets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: assets
+
 stat:
 	git branch
 	git status -s
@@ -6,6 +8,9 @@ test: stat
 	./cibuild.sh
 
 build: test
+
+assets:
+	./assets_sync.sh
 
 install:
 	bundle install

--- a/README.md
+++ b/README.md
@@ -56,6 +56,25 @@ You may run `make test`, or `make build`, or `make serve` to test and review you
 
 If Travis CI has built and deployed the `develop` branch successfully, you may merge it into the `master` branch.  You can do this by running `make publish`.  Your changes should be visible within 5 minutes on https://live.door43.org.
 
+#### Syncing Assets
+
+Assets (binary things like images) are housed on cdn.door43.org/assets for this site. This assets folder is a Resilio Sync folder shared among the developers (ask if you need access).
+
+##### Setup
+
+Initial setup requires getting the shared folder on your system.  Then you need to symlink the folder into the root of this project as "assets".  On my system I did this:
+
+    cd vcs/door43.org
+    ln -s /Users/jesse/BitTorrent\ Sync/door43.org.assets/ assets
+
+If you need `s3cmd`, then install it from http://s3tools.org/download.  It's as easy as `yum install s3cmd` or `sudo apt-get install s3cmd` for Linux.
+
+You will also need to ensure that you have a configuration file for `s3cmd` available as `s3cfg-prod` at the root of the repo.  Both the assets and s3cfg-prod locations are excluded from git in .gitignore.
+
+##### Syncing
+
+In order to synchronize the assets to the cdn S3 bucket you may now run `make assets`.  This process will **not remove** assets from the /assets folder, only add or update existing files.
+
 #### Open source acknowledgements
 
 * http://jekyllrb.com

--- a/_config.yml
+++ b/_config.yml
@@ -13,8 +13,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://live.door43.org"
 
 # Build settings
-exclude: [Gemfile*, README.md, LICENSE, s3*, secrets*, vender, cibuild.sh, Makefile]
-keep_files: [assets, assets/docs, assets/vid, assets/img, assets/fonts]
+exclude: [assets, assets_sync.sh, Gemfile*, README.md, LICENSE, s3*, secrets*, vender, cibuild.sh, Makefile]
 
 gems:
   - jekyll-sitemap

--- a/assets_sync.sh
+++ b/assets_sync.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# -*- coding: utf8 -*-
+#
+#  Copyright (c) 2017 unfoldingWord
+#  http://creativecommons.org/licenses/MIT/
+#  See LICENSE file for details.
+#
+#  Contributors:
+#  Jesse Griffin <jesse@unfoldingword.org>
+
+SOURCE="assets/"
+EXCLUDES="s3_excludes"
+BKT="s3://cdn.door43.org/assets/"
+
+echo "Note: Assets will not be deleted from S3"
+read -p "Sync $SOURCE to $BKT ? <Ctrl-C to break>"
+
+echo "Syncing to $BKT"
+s3cmd -c s3cfg-prod sync -M -F --no-mime-magic \
+    --exclude-from "$EXCLUDES" \
+    --add-header="Cache-Control:max-age=600" \
+    "$SOURCE" "$BKT"

--- a/s3_excludes
+++ b/s3_excludes
@@ -2,3 +2,5 @@
 u/*
 assets/.sync/*
 logs/*
+.DS_Store
+.sync/*


### PR DESCRIPTION
This includes:

* the assets_sync.sh script to actually do the sync to cdn.door43.org/assets/
* updated documentation in the README
* New target in Makefile, include PHONY line to force running the script
* Updated excludes in _config.yml and s3_excludes