### PR TITLE
Fix 528 - fix 404 page text

### DIFF
--- a/404.md
+++ b/404.md
@@ -5,7 +5,19 @@ sitemap: false
 permalink: /404.html
 ---
 
+<script>
+function getLink() {
+    var url = window.location.href;
+    var newUrl = url.toLowerCase().replace("live.door43.org/u", "git.door43.org");
+    var output = '<a href="' + newUrl + '">' + newUrl + '</a>'
+    return output;
+}
+</script>
+
 This probably means we could not convert the content<br/> 
-from https://git.door43.org/{PATH}.
+from <script>document.write(getLink());</script>  
 
 <a href="javascript: history.go(-1)">Go Back</a> to the previous page or [Contact Us](/en/contact) to let us know.
+
+
+


### PR DESCRIPTION
Fix https://github.com/unfoldingWord-dev/door43.org/issues/528 - fix 404 page text

> {PATH} should be the path to the repo on the Door43 Content Service.
> e.g https://live.door43.org/u/richmahn/en-obs3/ should link to https://git.door43.org/richmahn/en-obs3

Changes:
- Added javascript to embed url link to page.  
- Replaces "live.door43.org/u" with "git.door43.org".