### PR TITLE
Issue-382: revision list should behave same as contents list

### DIFF
--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -77,11 +77,11 @@ header {
  * Sidebar Nav
  */
 @media (min-width: 979px) {
-  #sidebar-nav {
+  #sidebar-nav, #revisions-div {
     width: 250px;
   }
 
-  #sidebar-nav.affix {
+  #sidebar-nav.affix, #revisions-div.affix {
     position: fixed;
     top: 80px;
     bottom: 0;
@@ -131,6 +131,16 @@ header {
       padding-top: 6px;
       padding-bottom: 12px;
     }
+  }
+}
+
+@media (max-width: 1199px) {
+  #sidebar-nav, #revisions-div {
+    width: 212px;
+  }
+
+  #sidebar-nav.affix, #revisions-div.affix {
+    width: 212px;
   }
 }
 

--- a/js/project-page.js
+++ b/js/project-page.js
@@ -2,7 +2,7 @@
  * Javascript for project commit pages to update the status and build the left sidebar
  */
 
-$(document).ready(function () {
+$().ready(function () {
   $('#starred-icon').click(function () {
     if ($(this).hasClass('starred')) {
       $(this).removeClass('starred');
@@ -88,23 +88,23 @@ $(document).ready(function () {
 
     if (scroll_top > margin_top - 10) {
       $pinned.addClass('pin-to-top');
-      $('#sidebar-nav').addClass('pin-to-top');
-
+      $('#sidebar-nav, #revisions-div').addClass('pin-to-top');
     }
     else {
       $pinned.removeClass('pin-to-top');
-      $('#sidebar-nav').removeClass('pin-to-top');
+      $('#sidebar-nav, #revisions-div').removeClass('pin-to-top');
     }
   });
 
   /* set up scrollspy */
   var navHeight = 122;
-  $('#sidebar-nav').affix({
+  $('#sidebar-nav, #revisions-div').affix({
     offset: {
       top: navHeight
     }
   });
   $('body').scrollspy({target: '#right-sidebar-nav', offset: navHeight});
+  $('body').scrollspy({target: '#left-sidebar-nav', offset: navHeight});
   /* smooth scrolling to sections with room for navbar */
   var $rightSidebarNav = $("#right-sidebar-nav");
   $rightSidebarNav.find("li a[href^='#']").on('click', function (e) {
@@ -128,7 +128,7 @@ $(document).ready(function () {
   }
 
   $(window).on('scroll resize', function () {
-    $('#sidebar-nav').css('bottom', getVisibleHeight('footer'));
+    $('#sidebar-nav, #revisions-div').css('bottom', getVisibleHeight('footer'));
   });
 });
 
@@ -162,7 +162,7 @@ function showTenMore(){
     hiddenRows[counter].style.display = '';
     counter++;
   }
-  
+
   // if all rows are now visible, hide the View More link
   if (counter >= hiddenRows.length) {
     $revisions.find('#view_more_tr').css('display', 'none');


### PR DESCRIPTION
* A scroll bar should appear for the revision history list when the number of displayed revisions exceeds the limit able to be displayed.

* Revision sidebar should float when the main content window is scrolled, just like the Navigation sidebar does.