### PR TITLE
Feature - Issue #548 - Makes project page template generic to support other resource types

### DIFF
--- a/_layouts/bible.html
+++ b/_layouts/bible.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+<!-- OBSOLETE! Please edit _layouts/project_page.html -->
 
 {% include head.html %}
 

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -1,11 +1,23 @@
 <!DOCTYPE html>
 <html>
 
-{% include head.html %}
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+{% strip %}
+{% include meta.html %}
+{% endstrip %}
+  <link rel="stylesheet" type="text/css" href="{{ '/css/main.css' | prepend: site.baseurl }}" media="screen">
+  <link rel="stylesheet" type="text/css" href="{{ '/css/print.css' | prepend: site.baseurl }}" media="print">
+
+  <!-- <link rel="" href="{{ '/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon"> -->
+
+  <link rel="stylesheet" type="text/css" href="{{ '/css/project-page.css' | prepend: site.baseurl }}">
+</head>
 
 <body itemscope="itemscope" itemtype="http://schema.org/WebPage">
-
-<link rel="stylesheet" type="text/css" href="{{ '/css/project-page.css' | prepend: site.baseurl }}">
 
 {% include header.html %}
 

--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -1,12 +1,11 @@
 <!DOCTYPE html>
 <html>
-<!-- OBSOLETE! Please edit _layouts/project_page.html -->
 
 {% include head.html %}
 
 <body itemscope="itemscope" itemtype="http://schema.org/WebPage">
+
 <link rel="stylesheet" type="text/css" href="{{ '/css/project-page.css' | prepend: site.baseurl }}">
-<link rel="stylesheet" type="text/css" href="{{ '/css/obs.css' | prepend: site.baseurl }}">
 
 {% include header.html %}
 
@@ -37,14 +36,14 @@
         </div>
     </div>
 </header>
-<div class="content-container container obs-container">
+<div class="container">
     <main class="content" role="main" itemprop="mainContentOfPage">
         <article itemscope="itemscope" itemtype="http://schema.org/CreativeWork">
             <div class="page-content row">
                 <div id="left-sidebar" class="col-md-3 sidebar" role="complementary">
                     { left-sidebar }
                 </div>
-                <div class="col-md-6 obs-outer-content" role="main" id="outer-content">
+                <div class="col-md-6" role="main" id="outer-content">
                     { content }
                 </div>
                 <div id="right-sidebar" class="col-md-3 sidebar" role="complementary">

--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -213,3 +213,80 @@ header {
     }
   }
 }
+
+/**
+ * Style for Bible navigation
+ */
+body.bible {
+  #sidebar-nav {
+    ul.chapters {
+      li.chapter {
+        list-style-type: none;
+        display: inline-block;
+        padding: 0;
+        margin: 3px;
+        width: 40px;
+        height: 40px;
+
+        a {
+          display: inline-block;
+          padding: 10px 0;
+          margin: 0;
+          background-color: #4e4e4e;
+          color: white;
+          height: 40px;
+          text-align: center;
+          vertical-align: middle;
+          width: 40px;
+        }
+
+        a:hover {
+          background-color: #949494;
+        }
+      }
+
+      li.chapter.active {
+        a {
+          background-color: #44ace8 !important;
+        }
+      }
+    }
+
+    .panel-heading {
+      .accordion-toggle:after {
+        font-family: 'Glyphicons Halflings';
+        content: "\e114";
+        float: right;
+        color: grey;
+      }
+      .accordion-toggle.collapsed:after {
+        /* symbol for "collapsed" panels */
+        content: "\e080"; /* adjust as needed, taken from bootstrap.css */
+      }
+    }
+  }
+}
+
+/**
+ * Style for tA project pages
+ */
+body.ta {
+  .page-title {
+    font-size: 18px;
+  }
+
+  #right-sidebar-nav {
+    ul li {
+      list-style-type: none;
+      margin-bottom: 5px;
+    }
+
+    h4 {
+      font-size: 18px;
+    }
+  }
+
+  #right-sidebar-nav > ul > li {
+    margin-left: 10px;
+  }
+}

--- a/js/general-tools.js
+++ b/js/general-tools.js
@@ -1,10 +1,6 @@
 /**
  * General functions for generating icons, dates, etc.
  */
-
-const DEFAULT_DOWNLOAD_LOCATION = "https://s3-us-west-2.amazonaws.com/tx-webhook-client/preconvert/";
-var source_download = null;
-
 function timeSince(date) {
     var seconds = Math.floor((new Date() - date) / 1000);
     var interval = Math.floor(seconds / 31536000);
@@ -133,40 +129,4 @@ function buildImageUrl(prefix, longWidth, largeHeight) {
     var middle = longWidth ? "-long" : "-short";
     var path = prefix + middle + suffix;
     return path;
-}
-
-
-/**
- * get URL for download
- * @param [pageUrl] if not set will use page href
- * @returns {*}
- */
-function getDownloadUrl(pageUrl) {
-    if(pageUrl == undefined) {
-        pageUrl=window.location.href
-    }
-
-    if(source_download) { // if found in build_log.json
-        return source_download;
-    }
-
-    var parts = pageUrl.split("/");
-    var commit = parts[6];
-    var download = DEFAULT_DOWNLOAD_LOCATION + commit + ".zip";
-    return download;
-}
-
-/**
- * get download link from build log
- * @param myLog
- */
-function saveDownloadLink(myLog) {
-    try {
-        source_download = myLog.source;
-        if(source_download) {
-            return;
-        }
-    } catch(e) {
-    }
-    source_download = null;
 }

--- a/js/project-page-functions.js
+++ b/js/project-page-functions.js
@@ -105,7 +105,7 @@ function onProjectPageLoaded() {
   });
 
   /* set up scrollspy */
-  var navHeight = 122;
+  var navHeight = $('.navbar').outerHeight(true);
   $('#sidebar-nav, #revisions-div').affix({
     offset: {
       top: navHeight
@@ -232,4 +232,42 @@ function setDcsHref(location) {
     href = getDcsLink(location.pathname);
 
   $('#see-on-dcs').attr('href', href);
+}
+
+const DEFAULT_DOWNLOAD_LOCATION = "https://s3-us-west-2.amazonaws.com/tx-webhook-client/preconvert/";
+var source_download = null;
+
+/**
+ * get URL for download
+ * @param [pageUrl] if not set will use page href
+ * @returns {*}
+ */
+function getDownloadUrl(pageUrl) {
+    if(pageUrl == undefined) {
+        pageUrl=window.location.href
+    }
+
+    if(source_download) { // if found in build_log.json
+        return source_download;
+    }
+
+    var parts = pageUrl.split("/");
+    var commit = parts[6];
+    var download = DEFAULT_DOWNLOAD_LOCATION + commit + ".zip";
+    return download;
+}
+
+/**
+ * get download link from build log
+ * @param myLog
+ */
+function saveDownloadLink(myLog) {
+    try {
+        source_download = myLog.source;
+        if(source_download) {
+            return;
+        }
+    } catch(e) {
+    }
+    source_download = null;
 }


### PR DESCRIPTION
In the light of having more resource types (e.g. 'tA' as per #548), it seems kind of laboring (and stupid) to have a template file for each resource (obs.html, bible.html, etc.) when they are all the same, three column layout. 

This PR safely handles this, still retaining the obs.html and bible.html templates (just in case) and their .css files, creating a `templates/project-page.html` template. This means all CSS will be in project-page.css from now on. tx-manager will download the project-page.html template for all resources when templating in the #548 PR for tx-manager counterpart.

A thing to note, the door43_deployer that's in tx-manager will add a class to the body tag that's the resource type, e.g. `<body class="ta">`, so we can style the navigation menu for a specific resource type, as you can see in my additions to project-page.scss

I have also moved the download link javascript to project-page-functions.js as it is not general, only for project pages.
