### PR TITLE
Fixes scrolling for both tA and Bible project pages

### DIFF
--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -271,14 +271,6 @@ body.bible {
  * Style for tA project pages
  */
 body.ta {
-  .page-title {
-    font-size: 18px;
-  }
-
-  .section-header {
-    padding-top: 80px;
-  }
-
   #right-sidebar-nav {
     ul li {
       list-style-type: none;
@@ -293,4 +285,10 @@ body.ta {
   #right-sidebar-nav > ul > li {
     margin-left: 10px;
   }
+}
+
+ul#sidebar-nav > li.active > a {
+  font-weight: normal;
+  color: #000000;
+  margin: 0;
 }

--- a/js/project-page-functions.js
+++ b/js/project-page-functions.js
@@ -112,8 +112,14 @@ function onProjectPageLoaded() {
     }
   });
   var $body = $('body');
-  $body.scrollspy({target: '#right-sidebar-nav', offset: navHeight});
-  $body.scrollspy({target: '#left-sidebar-nav', offset: navHeight});
+  $body.scrollspy({'target': '#right-sidebar-nav', 'offset':navHeight});
+  // Offset in the above for some reason doesn't work, so we fix it this way with a little hack:
+  var data = $body.data('bs.scrollspy');
+  if (data) {
+      data.options.offset = navHeight+100;
+      $body.data('bs.scrollspy', data);
+      $body.scrollspy('refresh');
+  }
   /* smooth scrolling to sections with room for navbar */
   var $rightSidebarNav = $("#right-sidebar-nav");
   $rightSidebarNav.find("li a[href^='#']").on('click', function (e) {
@@ -123,7 +129,7 @@ function onProjectPageLoaded() {
     var hash = this.hash;
     // animate
     $('html, body').animate({
-      scrollTop: $(hash).offset().top - navHeight
+      scrollTop: $(hash).offset().top - navHeight - 5
     }, 300, function () {
       // when done, add hash to url
       // (default click behaviour)

--- a/karma.conf.intellij.js
+++ b/karma.conf.intellij.js
@@ -6,6 +6,7 @@ module.exports = function(config) {
 
         files: [
             './js/jquery.min.js',
+          './js/bootstrap/bootstrap.min.js',
             './js/general-tools.js',
             './js/project-page-functions.js',
             './test/spec/*.js'

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,6 +5,8 @@ module.exports = function(config) {
 
         files: [
             './js/jquery.min.js',
+            './js/bootstrap/bootstrap.min.js',
+            './js/application.js',
             './js/general-tools.js',
             './js/project-page-functions.js',
             './test/spec/*.js'

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -13,6 +13,7 @@
 
   <!-- include source files here... -->
   <script src="../js/jquery.min.js"></script>
+  <script src="../js/bootstrap/bootstrap.min.js"></script>
   <script src="../js/general-tools.js"></script>
   <script src="../js/project-page-functions.js"></script>
 

--- a/test/spec/SpecSidebars.js
+++ b/test/spec/SpecSidebars.js
@@ -1,0 +1,24 @@
+
+describe('Test Project Sidebars', function () {
+
+  it('should set scrollspy data', function () {
+
+    // add the nav tags to the body
+    var $body = $(document.body);
+    $body.append('<nav class="navbar navbar-inverse navbar-fixed-top" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement" role="navigation">Top Nav Bar</nav>');
+    var $navbar = $('.navbar');
+    $navbar.css('height', 65);
+    $body.append('<nav class="affix-top hidden-print hidden-xs hidden-sm" id="right-sidebar-nav">Right Nav Bar</nav>');
+    $body.append('<div class="nav nav-stacked" id="revisions-div">Revisions</div>');
+    var $right_nav = $body.find('#right-side-nav');
+    $right_nav.append('<ul class="nav nav-stacked books panel-group" id="sidebar-nav"></ul>');
+
+    // run the onload function
+    onProjectPageLoaded();
+
+    // check for scrollspy data
+    var $data = $body.data('bs.scrollspy');
+    expect($data).toBeDefined();
+    expect($data.options.offset).toEqual(165);
+  });
+});


### PR DESCRIPTION
This handles scrolling better for both tA and Bible project pages, where any header with an ID in the content gets a padding-top of the actual navBar size (but still put 66px in the css since there is a delay), and then doesn't offset when doing the scrollspy to scroll to the header.

.page-title in the tA css isn't used.

Further change: now doesn't need any big padding before headers. It turns out setting offset in scrollspy only works if in the data-* attributes of the body tag. I found a way to add those so it behaves correctly.

See: http://test-door43.org.s3-website-us-west-2.amazonaws.com/u/tx-manager-test-data/en-ulb-123-john

and

http://test-door43.org.s3-website-us-west-2.amazonaws.com/u/Door43/en_ta/1288d00dd9/