### PR TITLE
Fix - Issue #575 - Fix for floating header with print and download buttons

### DIFF
--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -28,10 +28,10 @@
                 <span id="starred-icon"><i class="fa fa-star-o"></i></span>
                 <span id="h1">Header</span>
                 <span id="build-status-icon"><i class="fa fa-question-circle"></i></span>
-                <button id="print-button" class="btn btn-secondary hidden-print" onclick="printAll()"><span class="glyphicon glyphicon-print" aria-hidden="true"></span> Print</button>
+                <button id="print-button" class="btn btn-secondary hidden-print" onclick="printAll()"><span class="glyphicon glyphicon-print" aria-hidden="true"></span><span class="hide-on-pinned"> Print</span></button>
                 <span id="download_menu">
                     <span class="dropdown" >
-                        <button id="download_menu_button" class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown"><span class="glyphicon glyphicon-cloud-download"></span> Download
+                        <button id="download_menu_button" class="btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown"><span class="glyphicon glyphicon-cloud-download"></span><span class="hide-on-pinned"> Download</span>
                             <span class="caret"></span></button>
                         <ul class="dropdown-menu">
                             <li><a type="submit" onclick="window.open(getDownloadUrl())"><span class="glyphicon glyphicon-compressed"> MD</span></a></li>
@@ -41,7 +41,7 @@
             </h1>
         </div>
         <div id="sub-header">
-            <span id="last-updated">Updated ? hours ago</span>
+            <span id="last-updated" class="hide-on-pinned">Updated ? hours ago</span>
             <span id="views"><i class="fa fa-eye"></i></span>
             <span id="num-of-views"># views</span>
             <a id="see-on-dcs" href="" target="_blank">See on DCS</a>

--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -28,6 +28,8 @@ header {
             }
 
             #build-status-icon {
+                display: inline-block;
+                vertical-align: middle;
                 i {
                     font-size: 30px;
                     font-weight: 300;
@@ -138,7 +140,21 @@ header {
     margin-top: 0;
     top: 65px;
     box-shadow: 0 0 8px 1px #777;
-
+    #build-status-icon {
+      max-width: 35px;
+      overflow: hidden;
+    }
+    .hide-on-pinned {
+      display: none;
+    }
+    #header-title, #sub-header {
+      display: inline-block;
+    }
+    #sub-header {
+      position: fixed;
+      right: 20px;
+      top: 80px
+    }
     .container {
       padding-top: 6px;
       padding-bottom: 12px;

--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -129,6 +129,7 @@ header {
 // pin the header below the menu rather than scroll out of view
 #pinned-header {
   width: 100%;
+  margin-top: 130px;
   z-index: 100;
   background-color: #fff;
 
@@ -137,10 +138,6 @@ header {
     margin-top: 0;
     top: 65px;
     box-shadow: 0 0 8px 1px #777;
-
-    #header-title, #sub-header {
-      display: inline-block;
-    }
 
     .container {
       padding-top: 6px;

--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -129,8 +129,6 @@ header {
 // pin the header below the menu rather than scroll out of view
 #pinned-header {
   width: 100%;
-  margin-top: 130px;
-  margin-bottom: -130px;
   z-index: 100;
   background-color: #fff;
 
@@ -142,12 +140,6 @@ header {
 
     #header-title, #sub-header {
       display: inline-block;
-    }
-
-    #sub-header {
-      position: fixed;
-      right: 20px;
-      top: 80px
     }
 
     .container {

--- a/js/project-page-functions.js
+++ b/js/project-page-functions.js
@@ -1,5 +1,4 @@
-var myCommitId, myRepoName, myOwner;
-
+var myCommitId, myRepoName, myOwner, margin_top;
 /**
  * Called to initialize the project page
  */
@@ -88,20 +87,10 @@ function onProjectPageLoaded() {
     }); // End getJSON
 
   // pin the header below the menu rather than scroll out of view
-  var $pinned = $('#pinned-header');
-  var margin_top = parseInt($pinned.css('margin-top'));
+  margin_top = parseInt($('#pinned-header').css('margin-top'));
 
   $(document).on('scroll', function () {
-    var scroll_top = $(window).scrollTop();
-
-    if (scroll_top > margin_top - 10) {
-      $pinned.addClass('pin-to-top');
-      $('#sidebar-nav, #revisions-div').addClass('pin-to-top');
-    }
-    else {
-      $pinned.removeClass('pin-to-top');
-      $('#sidebar-nav, #revisions-div').removeClass('pin-to-top');
-    }
+    onDocumentScroll(window);
   });
 
   /* set up scrollspy */
@@ -145,6 +134,37 @@ function onProjectPageLoaded() {
   $(window).on('scroll resize', function () {
     $('#sidebar-nav, #revisions-div').css('bottom', getVisibleHeight('footer'));
   });
+}
+
+/**
+ * Called when the document scroll event fires.
+ *
+ * NOTE: the window object is passed as a parameter so the function is testable. Because of the
+ *       asynchronous nature of javascript, the unit test finishes before the onScroll event fires.
+ *
+ * @param theWindow
+ */
+function onDocumentScroll(theWindow) {
+
+  var $document = $(theWindow.document);
+  var scroll_top = theWindow.scrollY;
+  var $outer = $document.find('#outer-content');
+  var $pinned = $document.find('#pinned-header');
+
+  if (scroll_top > margin_top - 10) {
+    $pinned.addClass('pin-to-top');
+    $('#sidebar-nav, #revisions-div').addClass('pin-to-top');
+
+    if ($outer.css('marginTop') !== '240px')
+      $outer.css('marginTop', '240px');
+  }
+  else {
+    $pinned.removeClass('pin-to-top');
+    $('#sidebar-nav, #revisions-div').removeClass('pin-to-top');
+
+    if ($outer.css('marginTop') !== '0px')
+      $outer.css('marginTop', '0px');
+  }
 }
 
 function getVisibleHeight(selector) {

--- a/js/project-page-functions.js
+++ b/js/project-page-functions.js
@@ -108,7 +108,7 @@ function onProjectPageLoaded() {
   var navHeight = $('.navbar').outerHeight(true);
   $('#sidebar-nav, #revisions-div').affix({
     offset: {
-      top: navHeight
+      top: navHeight + margin_top
     }
   });
   var $body = $('body');

--- a/test/spec/SpecSidebars.js
+++ b/test/spec/SpecSidebars.js
@@ -1,24 +1,54 @@
 
 describe('Test Project Sidebars', function () {
 
-  it('should set scrollspy data', function () {
+  beforeEach(function () {
 
     // add the nav tags to the body
+    document.body.style.height = '5000px';
+    document.body.style.width = '1000px';
     var $body = $(document.body);
     $body.append('<nav class="navbar navbar-inverse navbar-fixed-top" itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement" role="navigation">Top Nav Bar</nav>');
     var $navbar = $('.navbar');
     $navbar.css('height', 65);
-    $body.append('<nav class="affix-top hidden-print hidden-xs hidden-sm" id="right-sidebar-nav">Right Nav Bar</nav>');
+    $body.append('<header id="pinned-header" style="margin-top: 130px">Pinned Header</header>');
     $body.append('<div class="nav nav-stacked" id="revisions-div">Revisions</div>');
+    $body.append('<div class="col-md-6" id="outer-content" role="main" style="height: 4000px">Content</div>');
+    $body.append('<nav class="affix-top hidden-print hidden-xs hidden-sm" id="right-sidebar-nav">Right Nav Bar</nav>');
+    $body.append('<footer class="site-footer" itemscope="itemscope" itemtype="http://schema.org/WPFooter" role="contentinfo">');
+
     var $right_nav = $body.find('#right-side-nav');
     $right_nav.append('<ul class="nav nav-stacked books panel-group" id="sidebar-nav"></ul>');
+  });
+
+  it('should set scrollspy data', function () {
 
     // run the onload function
     onProjectPageLoaded();
 
     // check for scrollspy data
-    var $data = $body.data('bs.scrollspy');
+    var $data = $(document.body).data('bs.scrollspy');
     expect($data).toBeDefined();
     expect($data.options.offset).toEqual(165);
+  });
+
+  it('should set outer-content margin-top', function () {
+
+    var $outer = $('#outer-content');
+
+    // margin-top should be zero
+    expect($outer.css('marginTop')).toEqual('0px');
+
+    // NOTE: We have to set window.scrollY = 2000 instead of using window.scroll(0, 2000) because the
+    //       PhantomJS browser expands to the size of the document, so scrolling doesn't happen.
+
+    // scroll down
+    window.scrollY = 2000;
+    onDocumentScroll(window);
+    expect($outer.css('marginTop')).toEqual('240px');
+
+    // scroll to top
+    window.scrollY = 0;
+    onDocumentScroll(window);
+    expect($outer.css('marginTop')).toEqual('0px');
   });
 });


### PR DESCRIPTION
Fixes the current problem on dev for floating header in project page: https://dev.door43.org/u/Door43/en_ta/68106ab6cd

Removing the bottom margin of the header tag, and the position fixed of the sub-header tag (putting the sub-header always on the second line due to the print and download button), this seems to make the header appear when at the top and floating to be correct.

Can see at http://test-door43.org.s3-website-us-west-2.amazonaws.com/u/Door43/en_ta/68106ab6cd/ and http://test-door43.org.s3-website-us-west-2.amazonaws.com/u/Door43/en_obs/ec7c9d9e8c/