### PR TITLE
Feature - Issue 444 - Completes the autocomplete by moving lc to filter area

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ s3cfg-prod
 secrets.tar
 node_modules/
 coverage/
-js/db-keys.json
+js/db_keys.js

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ In order to synchronize the assets to the cdn S3 bucket you may now run `make as
 - to make sure we have dependencies do `npm install`
 - to debug the tests do `./karma_start_debug.sh`
 - in Chrome open browser to `http://localhost:9876/#` and then click on Debug
-- then open "Developer Tools", set breakpoints (click Sources tab, js files are under base/test/spec) and then do refresh.
+- then open Chrome's "Developer Tools", set breakpoints (click Sources tab, js files are under base/test/spec) and then do refresh.
 - when done debugging, do `./karma_stop.sh` to stop karma running
 
 #### Open source acknowledgements

--- a/css/i18n.scss
+++ b/css/i18n.scss
@@ -138,6 +138,7 @@ div.clear {
       color: $navbar-inverse-link-color;
       text-align: center;
       cursor: pointer;
+      font-size: 18px;
     }
 
     #browse-td {
@@ -148,16 +149,45 @@ div.clear {
       padding: 0 8px;
       border-left: 3px solid #fff;
       white-space: nowrap;
+      font-size: 18px;
     }
 
-    #search-td:hover, #browse-td:hover {
+    #search-td:hover, #browse-td:hover, .lc-filter:hover {
       background-color: $navbar-inverse-bg;
     }
 
     #search-for {
-      height: 32px;
-      font-size: 16px;
+      height: 40px;
+      font-size: 18px;
       width: 300px;
+      vertical-align: top;
+    }
+
+    .lc-filter {
+      display: inline-block;
+      height: 40px;
+      padding: 8px 12px;
+      font-size: 16px;
+      font-style: italic;
+      font-weight: bold;
+      text-align: center;
+      vertical-align: top;
+      text-transform: uppercase;
+      margin-right: 5px;
+      background-color: $navbar-inverse-link-active-color;
+      color: $navbar-inverse-link-color;
+      cursor: pointer;
+      position: relative;
+
+      .remove-lc-x {
+        font-size: 10px;
+        color: #ffffff;
+        position: absolute;
+        right: 2px;
+        top: 1px;
+        text-transform: none;
+        font-weight: bold;
+      }
     }
   }
 }

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -174,30 +174,9 @@ function setupLanguageSelector() {
     languageSelectorKeyUp(event);
   });
 
-  $searchFor.on('autocompleteclose', function () {
-    parseLanguagePrompt(jQuery(this).val());
-  });
-
   $('body').on('click', '.lc-filter, .remove-lc.x', function(event){
     removeLanguageFilter(event.target);
   });
-}
-
-function parseLanguagePrompt(langText) {
-    languageCode = languagePrompt = null;
-    if (!langText) return;
-
-    // if closed without picking from the list, do nothing
-    var endOfLang = langText.indexOf(')');
-    if (endOfLang < 3) return;
-
-    var langCodes = langText.match(/\(([a-z0-9-]+)\)$/i);
-
-    if ((!langCodes) || (langCodes.length !== 2)) return;
-
-    //save language code and readable string
-    languagePrompt = langText.substr(0, endOfLang+1);
-    languageCode = langCodes[1];
 }
 
 /**

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -348,8 +348,6 @@ function extractLastSearchTerm() {
   var terms = splitSearchTerms($searchFor.val());
   if(terms.length > 0)
     return terms.pop();
-  else
-    return '';
 }
 
 function removeLastSearchTerm(){

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -168,7 +168,10 @@ var languageSearchResults = {};
 function setupLanguageSelector() {
   var $searchFor = $('#search-for');
 
-  $searchFor.on('keyup', function (event) {
+  $searchFor.on('keyup', function (event, testEvent) {
+    if(typeof testEvent!== 'undefined'){
+      event = testEvent;
+    }
     languageSelectorKeyUp(event);
   });
 
@@ -194,36 +197,21 @@ function languageSelectorKeyUp(event) {
   var term = extractLastSearchTerm().toLowerCase().substr(0,4);
 
   // clear the list
-  if($textBox.autocomplete('instance'))
+  if($textBox.autocomplete('instance')) {
     $textBox.autocomplete('option', 'source', []);
-
-  if (typeof event['unitTest'] === 'undefined' && languageSearchResults[term] === undefined) {
-    languageSelectorTimer = setTimeout(languageSelectorTimeout, 500, event.target);
-  } else{
-    languageSelectorTimeout(event.target);
   }
-}
 
-/**
- * Use a timeout to prevent unnecessary searching while typing
- * @param {HTMLInputElement} textBox
- */
-function languageSelectorTimeout(textBox) {
+  if($textBox.val().length < 2) {
+    return;
+  }
 
-  // reset the timer flag
-  languageSelectorTimer = 0;
-
-  var $textBox = $(textBox);
-  var textVal = $textBox.val();
-
-  // limit the search to the first 4 characters
-  var thisSearch = (textVal.length > 4) ? textVal.substr(0, 4) : textVal;
-
-  // don't search for anything if length is less than 2
-  if (thisSearch.length < 2) return;
-
-  // if the search text has changed, refresh the list of languages
-  getLanguageListItems($textBox);
+  if(typeof languageSearchResults[term] === 'undefined') {
+    if (typeof event['unitTest'] === 'undefined') {
+      languageSelectorTimer = setTimeout(getLanguageListItems, 500, $textBox);
+    }
+  } else{
+    getLanguageListItems($textBox);
+  }
 }
 
 /**
@@ -245,7 +233,7 @@ function processLanguages($textBox, results, callback) {
     }
   }
 
-  if (!$textBox.hasClass('ui-autocomplete-input')) {
+  if (! $textBox.hasClass('ui-autocomplete-input')) {
     $textBox.autocomplete({
       minLength: 0,
       select: function(event, ui){
@@ -314,8 +302,10 @@ function sortLanguages(langA, langB, text) {
  * @param {function|Spy} [callback]  Optional. Initially added for unit testing
  */
 function getLanguageListItems($textBox, callback) {
+  // reset the timer flag
+  languageSelectorTimer = 0;
   var term = extractLastSearchTerm().toLowerCase().substr(0, 4);
-  if(languageSearchResults[term] !== undefined){
+  if(typeof languageSearchResults[term] !== 'undefined'){
     processLanguages($textBox, languageSearchResults[term], callback);
   } else {
     var request = {type: 'GET', url: 'https://door43.org:9096/?q=' + encodeURIComponent(term)};
@@ -347,7 +337,7 @@ function getMessageString(err, entries, search_for) {
 }
 
 function splitSearchTerms(val) {
-  if(val !== undefined)
+  if(typeof val !== 'undefined')
     return val.split( /\s+/ );
   else
     return [];

--- a/test/spec/SpecLanguageAutocomplete.js
+++ b/test/spec/SpecLanguageAutocomplete.js
@@ -15,7 +15,7 @@ describe('Test Language Selector Autocomplete', function () {
 
   it('search for "en" should work', function (done) {
 
-    var $search_for = $('body').find('#search-for');
+    var $search_for = $('#search-for');
 
     $search_for.val('e');
 
@@ -28,7 +28,7 @@ describe('Test Language Selector Autocomplete', function () {
     // expect not to search on fist key press
     $search_for.trigger('keyup', event);
     languageSelectorTimeout(event.target);
-    expect($search_for.attr('data-last-search')).toBeUndefined();
+    expect($search_for.attr('data-last-search')).toEqual('e');
 
     $search_for.val('en');
     event.which = 'n'.charCodeAt(0);
@@ -52,4 +52,50 @@ describe('Test Language Selector Autocomplete', function () {
     });
   });
 
+  it('Adding and removing a button for "en"', function (done) {
+    expect(getLanguageCodesToFilter()).toEqual([]);
+
+    addLanguageFilter('en');
+    expect($('#lc-filter-en').length).toEqual(1);
+
+    // Adding again should not make another button
+    addLanguageFilter('en');
+    expect($('#lc-filter-en').length).toEqual(1);
+
+    // Adding "fr" should result in two buttons
+    addLanguageFilter('fr');
+    expect($('.lc-filter').length).toEqual(2);
+    expect(getLanguageCodesToFilter()).toEqual(['en', 'fr']);
+
+    // Removing "en" should have no #lc-filter-en and one .lc-filter
+    removeLanguageFilter('en');
+    expect($('#lc-filter-en').length).toEqual(0);
+    expect($('.lc-filter').length).toEqual(1);
+    expect(getLanguageCodesToFilter()).toEqual(['fr']);
+  });
+
+  it('Test functions for getting terms from the search field', function (done) {
+    var $searchFor = $('#search-for');
+    $searchFor.val('test1 test2 test3');
+
+    expect(extractLastSearchTerm()).toEqual('test3');
+
+    removeLastSearchTerm();
+    expect($searchFor.val()).toEqual('test1 test2');
+
+    removeLastSearchTerm();
+    expect($searchFor.val()).toEqual('test1');
+
+    removeLastSearchTerm();
+    expect($searchFor.val()).toEqual('');
+
+    removeLastSearchTerm();
+    expect($searchFor.val()).toEqual('');
+  });
+
+  it('Test splitSearchTerms function', function(done) {
+    expect(splitSearchTerms('val1 val2')).toEqual(['val1', 'val2']);
+    expect(splitSearchTerms('val1')).toEqual(['val1']);
+    expect(splitSearchTerms('')).toEqual(['']);
+  });
 });

--- a/test/spec/SpecLanguageAutocomplete.js
+++ b/test/spec/SpecLanguageAutocomplete.js
@@ -55,20 +55,22 @@ describe('Test Language Selector Autocomplete', function () {
   it('Adding and removing a button for "en"', function (done) {
     expect(getLanguageCodesToFilter()).toEqual([]);
 
-    addLanguageFilter('en');
+    addLanguageFilter({'lc':'en','ang':'English','ln':'English'});
     expect($('#lc-filter-en').length).toEqual(1);
+    expect($('#lc-filter-en').prop('title')).toEqual('English (en)');
 
     // Adding again should not make another button
-    addLanguageFilter('en');
+    addLanguageFilter({'lc':'en','ang':'English','ln':'English'});
     expect($('#lc-filter-en').length).toEqual(1);
 
     // Adding "fr" should result in two buttons
-    addLanguageFilter('fr');
+    addLanguageFilter({'lc':'fr','ang':'French','ln':'français, langue française'});
     expect($('.lc-filter').length).toEqual(2);
     expect(getLanguageCodesToFilter()).toEqual(['en', 'fr']);
+    expect($('#lc-filter-fr').prop('title')).toEqual('français, langue française - French (fr)');
 
     // Removing "en" should have no #lc-filter-en and one .lc-filter
-    removeLanguageFilter('en');
+    removeLanguageFilter(document.getElementById('lc-filter-en'));
     expect($('#lc-filter-en').length).toEqual(0);
     expect($('.lc-filter').length).toEqual(1);
     expect(getLanguageCodesToFilter()).toEqual(['fr']);

--- a/test/spec/SpecLanguageAutocomplete.js
+++ b/test/spec/SpecLanguageAutocomplete.js
@@ -52,7 +52,7 @@ describe('Test Language Selector Autocomplete', function () {
     });
   });
 
-  it('Adding and removing a button for "en"', function (done) {
+  it('Adding and removing a button for "en"', function () {
     expect(getLanguageCodesToFilter()).toEqual([]);
 
     addLanguageFilter({'lc':'en','ang':'English','ln':'English'});
@@ -76,7 +76,7 @@ describe('Test Language Selector Autocomplete', function () {
     expect(getLanguageCodesToFilter()).toEqual(['fr']);
   });
 
-  it('Test functions for getting terms from the search field', function (done) {
+  it('Test functions for getting terms from the search field', function () {
     var $searchFor = $('#search-for');
     $searchFor.val('test1 test2 test3');
 
@@ -95,7 +95,7 @@ describe('Test Language Selector Autocomplete', function () {
     expect($searchFor.val()).toEqual('');
   });
 
-  it('Test splitSearchTerms function', function(done) {
+  it('Test splitSearchTerms function', function() {
     expect(splitSearchTerms('val1 val2')).toEqual(['val1', 'val2']);
     expect(splitSearchTerms('val1')).toEqual(['val1']);
     expect(splitSearchTerms('')).toEqual(['']);

--- a/test/spec/SpecLanguageAutocomplete.js
+++ b/test/spec/SpecLanguageAutocomplete.js
@@ -2,7 +2,6 @@
 describe('Test Language Selector Autocomplete', function () {
 
   beforeEach(function () {
-
     jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
 
     loadFixtures('i18n-language-page-fixture.html');
@@ -13,8 +12,7 @@ describe('Test Language Selector Autocomplete', function () {
     setupLanguageSelector();
   });
 
-  it('search for "en" should work', function (done) {
-
+  it('Test autocomplete in the search field. Search for "en" should work', function (done) {
     var $search_for = $('#search-for');
 
     $search_for.val('e');
@@ -28,76 +26,93 @@ describe('Test Language Selector Autocomplete', function () {
     // expect not to search on fist key press
     $search_for.trigger('keyup', event);
     languageSelectorTimeout(event.target);
-    expect($search_for.attr('data-last-search')).toEqual('e');
 
     $search_for.val('en');
     event.which = 'n'.charCodeAt(0);
     $search_for.trigger('keyup', event);
     languageSelectorTimeout(event.target);
-    expect($search_for.attr('data-last-search')).toEqual('en');
 
     getLanguageListItems($search_for, function(languages) {
-
       // the first item should be 'English (en)'
-      expect(languages.length).toBeGreaterThan(0);
-      expect(languages[0]['lc']).toEqual('en');
+      var expectedLength = 0;
+      expect(languages.length).toBeGreaterThan(expectedLength);
+      var expectedLc = 'en';
+      expect(languages[0]['lc']).toEqual(expectedLc);
 
       // each language code should begin with 'en'
       var ul = jQuery('ul.ui-autocomplete')[0];
       jQuery(ul).find('li').each(function() {
-
-        expect(this.innerHTML.toLowerCase()).toContain(' (en');
+        var expectedText = ' (en';
+        expect(this.innerHTML.toLowerCase()).toContain(expectedText);
       });
       done();
     });
   });
 
   it('Adding and removing a button for "en"', function () {
-    expect(getLanguageCodesToFilter()).toEqual([]);
+    var expectedLcs = [];
+    expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
 
     addLanguageFilter({'lc':'en','ang':'English','ln':'English'});
-    expect($('#lc-filter-en').length).toEqual(1);
-    expect($('#lc-filter-en').prop('title')).toEqual('English (en)');
+    var expectedLength = 1;
+    var expectedTitle = 'English (en)';
+    expect($('#lc-filter-en').length).toEqual(expectedLength);
+    expect($('#lc-filter-en').prop('title')).toEqual(expectedTitle);
 
     // Adding again should not make another button
     addLanguageFilter({'lc':'en','ang':'English','ln':'English'});
-    expect($('#lc-filter-en').length).toEqual(1);
+    expectedLength = 1;
+    expect($('#lc-filter-en').length).toEqual(expectedLength);
 
     // Adding "fr" should result in two buttons
     addLanguageFilter({'lc':'fr','ang':'French','ln':'français, langue française'});
-    expect($('.lc-filter').length).toEqual(2);
-    expect(getLanguageCodesToFilter()).toEqual(['en', 'fr']);
-    expect($('#lc-filter-fr').prop('title')).toEqual('français, langue française - French (fr)');
+    expectedLength = 2;
+    var expectedLcs = ['en', 'fr'];
+    expectedTitle = 'français, langue française - French (fr)';
+    expect($('.lc-filter').length).toEqual(expectedLength);
+    expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
+    expect($('#lc-filter-fr').prop('title')).toEqual(expectedTitle);
 
     // Removing "en" should have no #lc-filter-en and one .lc-filter
     removeLanguageFilter(document.getElementById('lc-filter-en'));
-    expect($('#lc-filter-en').length).toEqual(0);
-    expect($('.lc-filter').length).toEqual(1);
-    expect(getLanguageCodesToFilter()).toEqual(['fr']);
+    expectedLength = 0;
+    expect($('#lc-filter-en').length).toEqual(expectedLength);
+    expectedLength = 1;
+    expectedLcs = ['fr'];
+    expect($('.lc-filter').length).toEqual(expectedLength);
+    expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
   });
 
   it('Test functions for getting terms from the search field', function () {
     var $searchFor = $('#search-for');
     $searchFor.val('test1 test2 test3');
 
-    expect(extractLastSearchTerm()).toEqual('test3');
+    var expectedTerm = 'test3';
+    expect(extractLastSearchTerm()).toEqual(expectedTerm);
 
     removeLastSearchTerm();
-    expect($searchFor.val()).toEqual('test1 test2');
+    expectedTerm = 'test1 test2';
+    expect($searchFor.val()).toEqual(expectedTerm);
 
     removeLastSearchTerm();
-    expect($searchFor.val()).toEqual('test1');
+    expectedTerm = 'test1';
+    expect($searchFor.val()).toEqual(expectedTerm);
 
     removeLastSearchTerm();
-    expect($searchFor.val()).toEqual('');
+    expectedTerm = '';
+    expect($searchFor.val()).toEqual(expectedTerm);
 
     removeLastSearchTerm();
-    expect($searchFor.val()).toEqual('');
+    expectedTerm = '';
+    expect($searchFor.val()).toEqual(expectedTerm);
   });
 
   it('Test splitSearchTerms function', function() {
-    expect(splitSearchTerms('val1 val2')).toEqual(['val1', 'val2']);
-    expect(splitSearchTerms('val1')).toEqual(['val1']);
-    expect(splitSearchTerms('')).toEqual(['']);
+    var expectedTerms = ['val1', 'val2'];
+    expect(splitSearchTerms('val1 val2')).toEqual(expectedTerms);
+    expectedTerms = ['val1'];
+    expect(splitSearchTerms('val1')).toEqual(expectedTerms);
+    expectedTerms = [''];
+    expect(splitSearchTerms('')).toEqual(expectedTerms);
   });
 });

--- a/test/spec/SpecLanguageFilter.js
+++ b/test/spec/SpecLanguageFilter.js
@@ -1,5 +1,5 @@
 
-describe('Test Language Selector Autocomplete', function () {
+describe('Test Language Filters and the Selector Autocomplete', function () {
 
   beforeEach(function () {
     jasmine.getFixtures().fixturesPath = 'base/test/fixtures';
@@ -10,6 +10,20 @@ describe('Test Language Selector Autocomplete', function () {
     expect(jQuery('#jasmine-fixtures')).toBeTruthy();
 
     setupLanguageSelector();
+  });
+
+  it('Test keyup in search field', function(){
+    var $search_for = $('#search-for');
+
+    $search_for.val('e');
+
+    var event = {
+      target: $search_for[0],
+      which: 13
+    };
+
+    // expect not to search on enter (13)
+    $search_for.trigger('keyup', event);
   });
 
   it('Test autocomplete in the search field. Search for "en" should work', function (done) {
@@ -25,12 +39,10 @@ describe('Test Language Selector Autocomplete', function () {
 
     // expect not to search on fist key press
     $search_for.trigger('keyup', event);
-    languageSelectorTimeout(event.target);
 
     $search_for.val('en');
     event.which = 'n'.charCodeAt(0);
     $search_for.trigger('keyup', event);
-    languageSelectorTimeout(event.target);
 
     getLanguageListItems($search_for, function(languages) {
       // the first item should be 'English (en)'
@@ -45,6 +57,9 @@ describe('Test Language Selector Autocomplete', function () {
         var expectedText = ' (en';
         expect(this.innerHTML.toLowerCase()).toContain(expectedText);
       });
+
+      expect(languageSearchResults['en'] !== undefined).toBeTruthy();
+
       done();
     });
   });
@@ -67,18 +82,29 @@ describe('Test Language Selector Autocomplete', function () {
     // Adding "fr" should result in two buttons
     addLanguageFilter({'lc':'fr','ang':'French','ln':'français, langue française'});
     expectedLength = 2;
-    var expectedLcs = ['en', 'fr'];
+    expectedLcs = ['en', 'fr'];
     expectedTitle = 'français, langue française - French (fr)';
     expect($('.lc-filter').length).toEqual(expectedLength);
     expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
     expect($('#lc-filter-fr').prop('title')).toEqual(expectedTitle);
 
-    // Removing "en" should have no #lc-filter-en and one .lc-filter
+    // Removing "en" by clicking the filter button should have no #lc-filter-en and one .lc-filter
+    $('#lc-filter-en').trigger('click');
     removeLanguageFilter(document.getElementById('lc-filter-en'));
     expectedLength = 0;
     expect($('#lc-filter-en').length).toEqual(expectedLength);
     expectedLength = 1;
     expectedLcs = ['fr'];
+    expect($('.lc-filter').length).toEqual(expectedLength);
+    expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
+
+    // Removing "fr" by the 'x' element should have no #lc-filter-fr and no .lc-filter
+    $('#lc-filter-fr .remove-lc-x').trigger('click');
+    removeLanguageFilter(document.getElementById('lc-filter-en'));
+    expectedLength = 0;
+    expect($('#lc-filter-fr').length).toEqual(expectedLength);
+    expectedLength = 0;
+    expectedLcs = [];
     expect($('.lc-filter').length).toEqual(expectedLength);
     expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
   });
@@ -105,6 +131,9 @@ describe('Test Language Selector Autocomplete', function () {
     removeLastSearchTerm();
     expectedTerm = '';
     expect($searchFor.val()).toEqual(expectedTerm);
+
+    expectedTerm = '';
+    expect(extractLastSearchTerm()).toEqual(expectedTerm);
   });
 
   it('Test splitSearchTerms function', function() {
@@ -114,5 +143,7 @@ describe('Test Language Selector Autocomplete', function () {
     expect(splitSearchTerms('val1')).toEqual(expectedTerms);
     expectedTerms = [''];
     expect(splitSearchTerms('')).toEqual(expectedTerms);
+    expectedTerms = [];
+    expect(splitSearchTerms(undefined)).toEqual(expectedTerms);
   });
 });

--- a/test/spec/SpecLanguageFilter.js
+++ b/test/spec/SpecLanguageFilter.js
@@ -52,14 +52,22 @@ describe('Test Language Filters and the Selector Autocomplete', function () {
       expect(languages[0]['lc']).toEqual(expectedLc);
 
       // each language code should begin with 'en'
-      var ul = jQuery('ul.ui-autocomplete')[0];
-      jQuery(ul).find('li').each(function() {
+      $('ul.ui-autocomplete li').each(function() {
         var expectedText = ' (en';
         expect(this.innerHTML.toLowerCase()).toContain(expectedText);
       });
+      $('ul.ui-autocomplete li:first-child').first().trigger('click');
+      var expectedVal = '';
+      expect($search_for.val()).toEqual(expectedVal);
+      var expectedLcs = ['en'];
+      expect(getLanguageCodesToFilter()).toEqual(expectedLcs);
 
       expect(languageSearchResults['en'] !== undefined).toBeTruthy();
 
+      // calling getLanguageListItems a second time should not need to do a timer
+      $search_for.autocomplete('instance').term = null;
+      getLanguageListItems($search_for);
+      expect($('ul.ui-autocomplete li').length).toBeGreaterThan(0);
       done();
     });
   });

--- a/test/spec/SpecManifestSearch.js
+++ b/test/spec/SpecManifestSearch.js
@@ -6,62 +6,6 @@ describe('Test Manifest Search', function () {
   var returnedError;
   var returnedEntries;
 
-    it('parseLanguagePrompt: parse valid language search', function () {
-        //given
-        var langText = 'Espanol (es)';
-        var expectedLanguageCode = 'es';
-        var expectedLanguagePrompt = langText;
-
-        //when
-        parseLanguagePrompt(langText);
-
-        //then
-        expect(languageCode).toEqual(expectedLanguageCode);
-        expect(languagePrompt).toEqual(expectedLanguagePrompt);
-    });
-
-    it('parseLanguagePrompt: parse null language search', function () {
-        //given
-        var langText = null;
-        var expectedLanguageCode = null;
-        var expectedLanguagePrompt = null;
-
-        //when
-        parseLanguagePrompt(langText);
-
-        //then
-        expect(languageCode).toEqual(expectedLanguageCode);
-        expect(languagePrompt).toEqual(expectedLanguagePrompt);
-    });
-
-    it('parseLanguagePrompt: parse too short language search', function () {
-        //given
-        var langText = 'es)';
-        var expectedLanguageCode = null;
-        var expectedLanguagePrompt = null;
-
-        //when
-        parseLanguagePrompt(langText);
-
-        //then
-        expect(languageCode).toEqual(expectedLanguageCode);
-        expect(languagePrompt).toEqual(expectedLanguagePrompt);
-    });
-
-    it('parseLanguagePrompt: parse invalid language code', function () {
-        //given
-        var langText = 'Espanol (#)';
-        var expectedLanguageCode = null;
-        var expectedLanguagePrompt = null;
-
-        //when
-        parseLanguagePrompt(langText);
-
-        //then
-        expect(languageCode).toEqual(expectedLanguageCode);
-        expect(languagePrompt).toEqual(expectedLanguagePrompt);
-    });
-
     it('getMessageString: error should return error message', function () {
         //given
         var err = "Error";


### PR DESCRIPTION
I believe this is a continuation of Phil's #444 in order to get the language codes out of the search field since they are to be filtered (ORed) and not searched (ANDed). This creates the language code buttons to the left of the search bar to signify what languages are being filtered. The result will look like https://github.com/unfoldingWord-dev/door43.org/issues/27#issuecomment-258946795

This is required so that the language codes can be known (not mixed in with search terms) for #443 as well as my #445 so I know what is a search term (q=) and what are language codes (lc=) to put in the URL.

To get the language codes, such as for #443  you just have to call `getLanguageCodesToFilter()` to get an array of the codes.

It can be viewed at http://test-door43.org.s3-website-us-west-2.amazonaws.com/en/