### PR TITLE
Issue #541/Fix Right-To-Left Header for pinned header

### DIFF
--- a/_layouts/project-page.html
+++ b/_layouts/project-page.html
@@ -43,7 +43,7 @@
         <div id="sub-header">
             <span id="last-updated" class="hide-on-pinned">Updated ? hours ago</span>
             <span id="views"><i class="fa fa-eye"></i></span>
-            <span id="num-of-views"># views</span>
+            <span id="num-of-views" dir="ltr"># views</span>
             <a id="see-on-dcs" href="" target="_blank">See on DCS</a>
         </div>
     </div>

--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -609,6 +609,28 @@ body.ta {
   }
 }
 
+// over-ride layout for rtl
+[dir=rtl] {
+  #pinned-header.pin-to-top #sub-header {
+    position: inherit;
+    right: inherit;
+    top: inherit;
+    float: left;
+    margin-top: 15px;
+    margin-left: 0;
+
+    #num-of-views {
+      margin-right: inherit;
+      margin-left: 30px;
+    }
+  }
+
+  #pinned-header.pin-to-top #build-status-icon img {
+    position: sticky;
+    left: 0;
+  }
+}
+
 #warning-modal {
   .modal-dialog {
     overflow-y: initial;


### PR DESCRIPTION
Issue: #541

- project-page.html - set initial default dir attribute of #num-of-views so text will not be mixed with anchor text.
- project-page.scss - set special layout for rtl and #pinned-header.pin-to-top

See results at: http://test-door43.org.s3-website-us-west-2.amazonaws.com/u/photonomad0/ar_eph_text_ulb/39a099622d/index.html