### PR TITLE
Fixed link to language search page

### DIFF
--- a/js/application.js
+++ b/js/application.js
@@ -129,7 +129,7 @@ function changeMissingTextForLanguageCode(lang_code, subPath) {
         $div.append("<ul>");
         var $ul = $div.find('ul');
         if ($ul.length) {
-            var search_link = buildAnchor("/en?lc=" + lang_code, "'" + lang_code + "' content");
+            var search_link = buildAnchor("/en/?lc=" + lang_code, "'" + lang_code + "' content");
             appendLineItem($ul, "Try searching for " + search_link + ".");
             appendLineItem($ul, "<a href=\"javascript: history.go(-1)\">Go Back</a> to previous page.");
             var old_link = buildAnchor("http://dw.door43.org/" + subPath, "old door43.org site");


### PR DESCRIPTION
Previous links were not working as forward slash was missing.