### PR TITLE
Fix_696/Remove Hard Coded live.door43.org links

### DIFF
--- a/404.md
+++ b/404.md
@@ -7,8 +7,8 @@ permalink: /404.html
 
 <script>
 function getLink() {
-    var url = window.location.href;
-    var newUrl = url.toLowerCase().replace("live.door43.org/u", "git.door43.org");
+    var path = window.location.pathname;
+    var newUrl =  "http://git.door43.org" + path.replace( "/u/", "/");
     var output = '<a href="' + newUrl + '">' + newUrl + '</a>'
     return output;
 }


### PR DESCRIPTION
Issue: https://github.com/unfoldingWord-dev/door43.org/issues/696

fix content link in 404 page.