### PR TITLE
Fix 727/Make download link less difficult to use

### DIFF
--- a/_sass/customize_theme.scss
+++ b/_sass/customize_theme.scss
@@ -334,6 +334,11 @@ ul.navbar-nav > li {
 
     list-style-type: none;
 }
+
+.dropdown-menu {
+    margin: 0;
+}
+
 .dropdown-menu > li {
 
     list-style-type: none;


### PR DESCRIPTION
issue: https://github.com/unfoldingWord-dev/door43.org/issues/727

modified custom_theme.scss - removed margin on .dropdown-menu so menu doesn't disappear on slow mouse movement.