### PR TITLE
Fix/Remove page reloads due to conversion/deploy error.

### DIFF
--- a/js/project-page-functions.js
+++ b/js/project-page-functions.js
@@ -684,6 +684,8 @@ function reloadPage() {
     window.location.reload(true); // conversion finished, reload page
 }
 
+var lastStatus = -1;
+
 function checkConversionStatus() {
     $.getJSON("build_log.json", function (myLog) {
         var iconType = eConvStatus.ERROR;
@@ -695,11 +697,14 @@ function checkConversionStatus() {
             console.log("conversion error");
         } else if (iconType !== eConvStatus.IN_PROGRESS) {
             console.log("conversion completed");
-            reloadPage();
+            if(lastStatus === eConvStatus.IN_PROGRESS) {
+                reloadPage(); // only reload page if we went from in_progress to a final state
+            }
         } else {
             conversion_start_time = new Date(myLog.created_at);
             checkAgainForBuildCompletion();
         }
+        lastStatus = iconType;
     })
     .fail(function () {
         console.log("error reading build_log.json, retry in 10 seconds");

--- a/test/spec/SpecBuildInProcess.js
+++ b/test/spec/SpecBuildInProcess.js
@@ -50,8 +50,9 @@ describe('Test Processing of Json files', function () {
 
     describe('Test checkConversionStatus()', function () {
 
-        it('checkConversionStatus() status success should reload page', function () {
+        it('checkConversionStatus() status success should reload page if last read was pending', function () {
             // given
+            lastStatus = eConvStatus.IN_PROGRESS;
             var build_log = JSON.parse(JSON.stringify(build_log_base)); // clone
             mockGetJson(build_log);
             spyOn(window, 'reloadPage').and.returnValue(false);
@@ -62,6 +63,23 @@ describe('Test Processing of Json files', function () {
             // then
             expect(window.reloadPage).toHaveBeenCalled();
             expect(recent_build_log).toEqual(build_log);
+            expect(lastStatus).toEqual(eConvStatus.SUCCESS);
+        });
+
+        it('checkConversionStatus() status success should not reload page if last read was not pending', function () {
+            // given
+            lastStatus = -1;
+            var build_log = JSON.parse(JSON.stringify(build_log_base)); // clone
+            mockGetJson(build_log);
+            spyOn(window, 'reloadPage').and.returnValue(false);
+
+            // when
+            checkConversionStatus();
+
+            // then
+            expect(window.reloadPage).not.toHaveBeenCalled();
+            expect(recent_build_log).toEqual(build_log);
+            expect(lastStatus).toEqual(eConvStatus.SUCCESS);
         });
 
         it('checkConversionStatus() status requested should call checkAgainForBuildCompletion', function () {


### PR DESCRIPTION
project-page-functions.js - fix to only reload page if first status read was in_progress and then changed.