### PR TITLE
Fix jump-links and viewport positioning

### DIFF
--- a/css/project-page.scss
+++ b/css/project-page.scss
@@ -298,6 +298,18 @@ body.ta {
       -webkit-margin-start: 0;
       -webkit-margin-end: 0;
       font-weight: bold;
+
+      /**
+       * Make section headers appear lower appear lower on screen than their link targets, so
+       * they aren't obscured by the page header. Offset of 186px places headers even with the
+       * left column text ("Revisions"), but use about 150px just to clear the header.
+       * http://nicolasgallagher.com/jump-links-and-viewport-positioning/demo/#method-D
+       */
+      border-top: 186px solid transparent;
+      margin-top: -186px;
+      -webkit-background-clip: padding-box;
+      -moz-background-clip: padding;
+      background-clip: padding-box;
     }
 
     h1 + *, h2 + *, h3 + *, h4 + *, h5 + *, h6 + *,


### PR DESCRIPTION
Links to chapters within scripture (or subheadings within a help resource) scroll the target to the top of the browser viewport. However, the top of the viewport is covered by the floating header (the strip with logo and links to About, Browse, etc).

Fork/port/cherry-pick of fix for issue https://github.com/WycliffeAssociates/read.bibletranslationtools.org/issues/8

This fix uses a [negative margin trick](http://nicolasgallagher.com/jump-links-and-viewport-positioning/demo/#method-D) so section titles aren't obscured by page header.
